### PR TITLE
add Bytes to ObjHashable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-marshal"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Solomon Ucko <solly.ucko@gmail.com>"]
 edition = "2018"
 description = "A Rust port of https://github.com/python/cpython/blob/master/Python/marshal.c"


### PR DESCRIPTION
`str` is bytes in python2, and is the most common dict key, so it's necessary to support bytes as hashable when processing old data.